### PR TITLE
Enables more carping of diems with new --carpe-diem flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ git config --global alias.yolo git-yolo
 git yolo
 ```
 
+Your changes might have introduced breaking changes, but you got more important things to worry about in your short time on Earth, so you can make sure to bump the major version on every save with the `--carpe-diem` flag:
+
+```bash
+git-yolo --carpe-diem
+```
+
 ## But Y DOE?
 
 Well simple.
@@ -51,5 +57,4 @@ Just press Save!
 
 This should probably be slightly more customizable.
 - For instance if you have a CI perhaps you should be able to include a `[ci-skip]` in the commit message.
-- Extreme mode: The option to also bump the version at every new commit and tag it.
-Perhaps `--carpe-diem`
+

--- a/bin/git-yolo
+++ b/bin/git-yolo
@@ -3,8 +3,10 @@
 var SimpleGit = require('simple-git');
 var path = process.cwd();
 var fs = require('fs');
+var spawn = require('cross-spawn');
 
 var repository = SimpleGit(path);
+var flags = process.argv.slice(2);
 
 Array.prototype.random = function () {
     var index = Math.floor(Math.random() * this.length);
@@ -31,10 +33,19 @@ var emojis = [
     "¯\\_(ツ)_/¯"
 ];
 
+function hasFlag(flag) {
+    return flags.indexOf(flag) >= 0;
+}
+
 function yolo(file, callback) {
     if (file) {
         console.log("Change in: " + file);
     }
+
+    if (hasFlag('--carpe-diem')) {
+        spawn.sync('npm', ['version', 'major']);
+    }
+
     var message = "YOLO!!! " + emojis.random() + (file ?  " Changed: " + file : "");
     repository
         .add('.')
@@ -56,5 +67,5 @@ function listen() {
 }
 
 // This really works
-console.log("Starting YOLO Mode");
+console.log("Starting YOLO Mode" + (hasFlag('--carpe-diem') ? " with extra Carpe Diem™" : ""));
 yolo(undefined, listen);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/mathiasquintero/git-yolo#readme",
   "dependencies": {
+    "cross-spawn": "^5.1.0",
     "simple-git": "^1.73.0"
   }
 }


### PR DESCRIPTION
Unburden yourself from the yoke of backwards compatibility with the new `--carpe-diem` flag. Press save and a major version bump will automatically be performed for you.